### PR TITLE
feat: use an unprivileged user during runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,20 @@ FROM alpine:3.22.1
 
 RUN apk --no-cache add ca-certificates
 
-WORKDIR /root/
+# Setup an unprivileged user
+RUN addgroup -g 1000 appgroup && \
+    adduser -D -u 1000 -G appgroup appuser
+
+WORKDIR /app
+RUN chown appuser:appgroup /app
+
+USER appuser
 
 # Copy the binary from builder stage
-COPY --from=builder /app/zigbee2mqtt-exporter .
+COPY --from=builder --chown=appuser:appuser /app/zigbee2mqtt-exporter .
 
 # Expose port
 EXPOSE 8087
 
 # Run the binary
-CMD ["./zigbee2mqtt-exporter"]
+CMD ["/app/zigbee2mqtt-exporter"]


### PR DESCRIPTION
It's good practice to not use the root user (uid 0) during runtime. The application already uses an
unprivileged port.

This allows you to run the container on  Kubernetes with the Pod `securityContext`:

```yaml
  securityContext:
    runAsNonRoot: true
    runAsUser: 1000
    runAsGroup: 1000
    fsGroup: 1000
    fsGroupChangePolicy: OnRootMismatch
    seccompProfile:
      type: RuntimeDefault
```

and the container `securityContext`:

```yaml
        securityContext:
          allowPrivilegeEscalation: false
          readOnlyRootFilesystem: true
          capabilities:
            drop: ["ALL"]
```