### PR TITLE
feat: pin versions in documentation and examples

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,16 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "include-component-in-tag": false,
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "extra-files": [],
+      "versioning": "default",
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "chore", "section": "Dependencies"},
+        {"type": "deps", "section": "Dependencies"}
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Prometheus exporter for Zigbee2MQTT that connects to the WebSocket API and exports device metrics with device type classification.
 
-**Image**: `ghcr.io/d0ugal/zigbee2mqtt-exporter:latest`
+**Image**: `ghcr.io/d0ugal/zigbee2mqtt-exporter:v2.13.2`
 
 ## Metrics
 
@@ -43,7 +43,7 @@ A Prometheus exporter for Zigbee2MQTT that connects to the WebSocket API and exp
 version: '3.8'
 services:
   zigbee2mqtt-exporter:
-    image: ghcr.io/d0ugal/zigbee2mqtt-exporter:latest
+    image: ghcr.io/d0ugal/zigbee2mqtt-exporter:v2.13.2
     ports:
       - "8087:8087"
     environment:
@@ -73,7 +73,7 @@ services:
 version: '3.8'
 services:
   zigbee2mqtt-exporter:
-    image: ghcr.io/d0ugal/zigbee2mqtt-exporter:latest
+    image: ghcr.io/d0ugal/zigbee2mqtt-exporter:v2.13.2
     ports:
       - "8087:8087"
     environment:
@@ -101,7 +101,7 @@ spec:
     spec:
       containers:
       - name: zigbee2mqtt-exporter
-        image: ghcr.io/d0ugal/zigbee2mqtt-exporter:latest
+        image: ghcr.io/d0ugal/zigbee2mqtt-exporter:v2.13.2
         ports:
         - containerPort: 8087
         env:

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sys v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -35,11 +35,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
-go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 go.yaml.in/yaml/v2 v2.4.3 h1:6gvOSjQoTB3vt1l+CU+tSyi/HOjfOjRLJ4YwYZGwRO0=
 go.yaml.in/yaml/v2 v2.4.3/go.mod h1:zSxWcmIDjOzPXpjlTTbAsKokqkDNAVtZO0WOMiT90s8=
-go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
 golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,10 +32,6 @@
       enabled: true,
     },
   ],
-  // Configure commit message format for dependency updates
-  commitMessagePrefix: 'chore(deps):',
-  commitMessageAction: 'update',
-  commitMessageTopic: 'dependencies',
   customManagers: [
     {
       customType: 'regex',

--- a/renovate.json5
+++ b/renovate.json5
@@ -32,6 +32,10 @@
       enabled: true,
     },
   ],
+  // Configure commit message format for dependency updates
+  commitMessagePrefix: 'chore(deps):',
+  commitMessageAction: 'update',
+  commitMessageTopic: 'dependencies',
   customManagers: [
     {
       customType: 'regex',

--- a/renovate.json5
+++ b/renovate.json5
@@ -45,5 +45,17 @@
       datasourceTemplate: 'docker',
       versioningTemplate: 'semver',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '**/*.md',
+      ],
+      matchStrings: [
+        'ghcr\\.io/d0ugal/zigbee2mqtt-exporter:(?<currentValue>v[\\d\\.]+)',
+      ],
+      depNameTemplate: 'ghcr.io/d0ugal/zigbee2mqtt-exporter',
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'semver',
+    },
   ],
 }


### PR DESCRIPTION
## 📌 Pin Versions in Documentation

This PR replaces all  references with pinned versions in documentation and examples.

### Changes:
- ✅ Replace  with pinned versions in README.md
- ✅ Add renovate custom manager for markdown files to auto-update pinned versions  
- ✅ Remove Docker Compose custom managers (handled automatically by Renovate)
- ✅ Ensure users get stable, tested versions instead of potentially unstable 

### Benefits:
- 🎯 **Consistent versions** across all documentation and examples
- 🔄 **Renovate will automatically update** pinned versions when new releases are available
- 🛡️ **Users get stable, tested versions** instead of potentially unstable 
- 📈 **Better reproducibility** for users following the documentation