### PR TITLE
fix: parse update.state from device messages to set OTA update metric

### DIFF
--- a/internal/collectors/z2m_collector.go
+++ b/internal/collectors/z2m_collector.go
@@ -1204,6 +1204,31 @@ func (c *Z2MCollector) updateDeviceMetrics(ctx context.Context, deviceName strin
 		metricsUpdated++
 	}
 
+	// Update OTA state from the "update" object published on device state topics.
+	// Z2M publishes update.state as idle|available|scheduled|updating alongside
+	// device state — available/scheduled/updating all mean an update is pending.
+	if updateData, ok := data["update"].(map[string]interface{}); ok {
+		if otaState, ok := updateData["state"].(string); ok {
+			updateAvailable := 0.0
+			if otaState == "available" || otaState == "scheduled" || otaState == "updating" {
+				updateAvailable = 1.0
+			}
+
+			c.metrics.DeviceOTAUpdateAvailable.With(prometheus.Labels{
+				"device": deviceName,
+			}).Set(updateAvailable)
+
+			metricsUpdated++
+
+			if span != nil {
+				span.SetAttributes(
+					attribute.String("device.ota_state", otaState),
+					attribute.Float64("device.ota_update_available", updateAvailable),
+				)
+			}
+		}
+	}
+
 	updateDuration := time.Since(updateStart)
 
 	if span != nil {

--- a/internal/collectors/z2m_collector_test.go
+++ b/internal/collectors/z2m_collector_test.go
@@ -1,35 +1,77 @@
 package collectors
 
 import (
+	"context"
 	"testing"
 
 	"github.com/d0ugal/promexporter/app"
 	promexporter_metrics "github.com/d0ugal/promexporter/metrics"
 	"github.com/d0ugal/zigbee2mqtt-exporter/internal/config"
 	"github.com/d0ugal/zigbee2mqtt-exporter/internal/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
-func TestNewZ2MCollector(t *testing.T) {
+func newTestCollector(t *testing.T) (*Z2MCollector, *metrics.Z2MRegistry) {
+	t.Helper()
+
 	cfg := &config.Config{
 		WebSocket: config.WebSocketConfig{
 			URL: "ws://localhost:8081/api",
 		},
 	}
 
-	// Create a mock base registry for testing
 	baseRegistry := promexporter_metrics.NewRegistry("test_exporter_info")
 	registry := metrics.NewZ2MRegistry(baseRegistry)
-
-	// Create a minimal app instance for testing
 	testApp := app.New("Test Exporter").
 		WithConfig(&cfg.BaseConfig).
 		WithMetrics(baseRegistry).
 		Build()
 
-	// Test that NewZ2MCollector doesn't panic
-	collector := NewZ2MCollector(cfg, registry, testApp)
+	return NewZ2MCollector(cfg, registry, testApp), registry
+}
+
+func TestNewZ2MCollector(t *testing.T) {
+	collector, _ := newTestCollector(t)
 
 	if collector == nil {
 		t.Error("Expected collector to not be nil")
+	}
+}
+
+func TestUpdateDeviceMetrics_OTAState(t *testing.T) {
+	tests := []struct {
+		name          string
+		otaState      string
+		expectedGauge float64
+	}{
+		{"idle means no update", "idle", 0.0},
+		{"available means update pending", "available", 1.0},
+		{"scheduled means update pending", "scheduled", 1.0},
+		{"updating means update in progress", "updating", 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector, registry := newTestCollector(t)
+
+			payload := map[string]interface{}{
+				"update": map[string]interface{}{
+					"state":             tt.otaState,
+					"installed_version": float64(620834817),
+					"latest_version":    float64(620834817),
+				},
+			}
+
+			collector.updateDeviceMetrics(context.Background(), "test_device", payload)
+
+			got := testutil.ToFloat64(registry.DeviceOTAUpdateAvailable.With(prometheus.Labels{
+				"device": "test_device",
+			}))
+
+			if got != tt.expectedGauge {
+				t.Errorf("OTA state %q: got %v, want %v", tt.otaState, got, tt.expectedGauge)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #562

## Problem

`zigbee2mqtt_device_ota_update_available` was only being populated from the `bridge/devices` topic (which uses the legacy `update_available` boolean field). Z2M also publishes an `update` object on every device state topic (e.g. `zigbee2mqtt/mydevice`) containing:

```json
{
  "state": "idle",
  "installed_version": 620834817,
  "latest_version": 620834817
}
```

Where `state` is one of `idle | available | scheduled | updating`. Devices that publish OTA state only this way were always showing 0.

## Fix

Read `update.state` in `updateDeviceMetrics` and set the gauge to 1 when state is `available`, `scheduled`, or `updating`; 0 for `idle`.

## Tests

Added `TestUpdateDeviceMetrics_OTAState` covering all four state values.