### PR TITLE
feat: replace ota_update_available with per-state metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ A Prometheus exporter for Zigbee2MQTT that connects to the WebSocket API and exp
 - `zigbee2mqtt_device_info{device,type,power_source,manufacturer,model_id,supported,disabled,interview_state,software_build_id,date_code}` - Device information (always 1, used for joining)
 
 ### OTA Update Metrics
-- `zigbee2mqtt_device_ota_update_available{device}` - Device OTA update availability (1=available, 0=not_available)
+- `zigbee2mqtt_device_ota_update_idle{device}` - Device OTA state: idle (1=in this state)
+- `zigbee2mqtt_device_ota_update_available{device}` - Device OTA state: available (1=in this state)
+- `zigbee2mqtt_device_ota_update_scheduled{device}` - Device OTA state: scheduled (1=in this state)
+- `zigbee2mqtt_device_ota_update_updating{device}` - Device OTA state: updating (1=in this state)
 - `zigbee2mqtt_device_current_firmware_version{device,firmware_version}` - Device current firmware version (always 1, used for joining)
 - `zigbee2mqtt_device_available_firmware_version{device,firmware_version}` - Device available firmware version (always 1, used for joining)
 
@@ -141,6 +144,18 @@ count by (type) (zigbee2mqtt_device_info)
 ### Get devices with OTA updates available
 ```promql
 zigbee2mqtt_device_ota_update_available == 1
+```
+
+### Get devices currently updating
+```promql
+zigbee2mqtt_device_ota_update_updating == 1
+```
+
+### Get count of devices in each OTA state
+```promql
+sum(zigbee2mqtt_device_ota_update_available)
+sum(zigbee2mqtt_device_ota_update_scheduled)
+sum(zigbee2mqtt_device_ota_update_updating)
 ```
 
 ### Get unsupported devices

--- a/internal/collectors/z2m_collector.go
+++ b/internal/collectors/z2m_collector.go
@@ -575,15 +575,17 @@ func (c *Z2MCollector) processBridgeDevicesMessage(ctx context.Context, msg Z2MM
 				}).Set(1)
 			}
 
-			// Update OTA update availability
-			updateAvailable := 0.0
+			// Update OTA metrics from bridge/devices boolean (no state granularity here)
+			idle, available := 1.0, 0.0
 			if device.UpdateAvailable {
-				updateAvailable = 1.0
+				idle, available = 0.0, 1.0
 			}
 
-			c.metrics.DeviceOTAUpdateAvailable.With(prometheus.Labels{
-				"device": device.FriendlyName,
-			}).Set(updateAvailable)
+			labels := prometheus.Labels{"device": device.FriendlyName}
+			c.metrics.DeviceOTAUpdateIdle.With(labels).Set(idle)
+			c.metrics.DeviceOTAUpdateAvailable.With(labels).Set(available)
+			c.metrics.DeviceOTAUpdateScheduled.With(labels).Set(0)
+			c.metrics.DeviceOTAUpdateUpdating.With(labels).Set(0)
 		}
 
 		return
@@ -1205,25 +1207,34 @@ func (c *Z2MCollector) updateDeviceMetrics(ctx context.Context, deviceName strin
 	}
 
 	// Update OTA state from the "update" object published on device state topics.
-	// Z2M publishes update.state as idle|available|scheduled|updating alongside
-	// device state — available/scheduled/updating all mean an update is pending.
+	// Z2M publishes update.state as idle|available|scheduled|updating — each maps
+	// to its own gauge so callers can alert on available-only without noise from
+	// in-progress updates.
 	if updateData, ok := data["update"].(map[string]interface{}); ok {
 		if otaState, ok := updateData["state"].(string); ok {
-			updateAvailable := 0.0
-			if otaState == "available" || otaState == "scheduled" || otaState == "updating" {
-				updateAvailable = 1.0
+			idle, available, scheduled, updating := 0.0, 0.0, 0.0, 0.0
+
+			switch otaState {
+			case "available":
+				available = 1.0
+			case "scheduled":
+				scheduled = 1.0
+			case "updating":
+				updating = 1.0
+			default:
+				idle = 1.0
 			}
 
-			c.metrics.DeviceOTAUpdateAvailable.With(prometheus.Labels{
-				"device": deviceName,
-			}).Set(updateAvailable)
-
-			metricsUpdated++
+			labels := prometheus.Labels{"device": deviceName}
+			c.metrics.DeviceOTAUpdateIdle.With(labels).Set(idle)
+			c.metrics.DeviceOTAUpdateAvailable.With(labels).Set(available)
+			c.metrics.DeviceOTAUpdateScheduled.With(labels).Set(scheduled)
+			c.metrics.DeviceOTAUpdateUpdating.With(labels).Set(updating)
+			metricsUpdated += 4
 
 			if span != nil {
 				span.SetAttributes(
 					attribute.String("device.ota_state", otaState),
-					attribute.Float64("device.ota_update_available", updateAvailable),
 				)
 			}
 		}

--- a/internal/collectors/z2m_collector.go
+++ b/internal/collectors/z2m_collector.go
@@ -1230,6 +1230,7 @@ func (c *Z2MCollector) updateDeviceMetrics(ctx context.Context, deviceName strin
 			c.metrics.DeviceOTAUpdateAvailable.With(labels).Set(available)
 			c.metrics.DeviceOTAUpdateScheduled.With(labels).Set(scheduled)
 			c.metrics.DeviceOTAUpdateUpdating.With(labels).Set(updating)
+
 			metricsUpdated += 4
 
 			if span != nil {

--- a/internal/collectors/z2m_collector_test.go
+++ b/internal/collectors/z2m_collector_test.go
@@ -71,6 +71,7 @@ func TestUpdateDeviceMetrics_OTAState(t *testing.T) {
 			labels := prometheus.Labels{"device": "test_device"}
 			check := func(name string, vec *prometheus.GaugeVec, want float64) {
 				t.Helper()
+
 				if got := testutil.ToFloat64(vec.With(labels)); got != want {
 					t.Errorf("OTA state %q: %s = %v, want %v", tt.otaState, name, got, want)
 				}

--- a/internal/collectors/z2m_collector_test.go
+++ b/internal/collectors/z2m_collector_test.go
@@ -41,14 +41,17 @@ func TestNewZ2MCollector(t *testing.T) {
 
 func TestUpdateDeviceMetrics_OTAState(t *testing.T) {
 	tests := []struct {
-		name          string
-		otaState      string
-		expectedGauge float64
+		name      string
+		otaState  string
+		wantIdle  float64
+		wantAvail float64
+		wantSched float64
+		wantUpd   float64
 	}{
-		{"idle means no update", "idle", 0.0},
-		{"available means update pending", "available", 1.0},
-		{"scheduled means update pending", "scheduled", 1.0},
-		{"updating means update in progress", "updating", 1.0},
+		{"idle", "idle", 1, 0, 0, 0},
+		{"available", "available", 0, 1, 0, 0},
+		{"scheduled", "scheduled", 0, 0, 1, 0},
+		{"updating", "updating", 0, 0, 0, 1},
 	}
 
 	for _, tt := range tests {
@@ -65,13 +68,18 @@ func TestUpdateDeviceMetrics_OTAState(t *testing.T) {
 
 			collector.updateDeviceMetrics(context.Background(), "test_device", payload)
 
-			got := testutil.ToFloat64(registry.DeviceOTAUpdateAvailable.With(prometheus.Labels{
-				"device": "test_device",
-			}))
-
-			if got != tt.expectedGauge {
-				t.Errorf("OTA state %q: got %v, want %v", tt.otaState, got, tt.expectedGauge)
+			labels := prometheus.Labels{"device": "test_device"}
+			check := func(name string, vec *prometheus.GaugeVec, want float64) {
+				t.Helper()
+				if got := testutil.ToFloat64(vec.With(labels)); got != want {
+					t.Errorf("OTA state %q: %s = %v, want %v", tt.otaState, name, got, want)
+				}
 			}
+
+			check("idle", registry.DeviceOTAUpdateIdle, tt.wantIdle)
+			check("available", registry.DeviceOTAUpdateAvailable, tt.wantAvail)
+			check("scheduled", registry.DeviceOTAUpdateScheduled, tt.wantSched)
+			check("updating", registry.DeviceOTAUpdateUpdating, tt.wantUpd)
 		})
 	}
 }

--- a/internal/metrics/z2m_registry.go
+++ b/internal/metrics/z2m_registry.go
@@ -32,8 +32,11 @@ type Z2MRegistry struct {
 	WebSocketMessagesTotal    *prometheus.CounterVec
 	WebSocketReconnectsTotal  *prometheus.CounterVec
 
-	// OTA Update metrics
+	// OTA Update metrics - one per state, value is 1 when device is in that state
+	DeviceOTAUpdateIdle      *prometheus.GaugeVec
 	DeviceOTAUpdateAvailable *prometheus.GaugeVec
+	DeviceOTAUpdateScheduled *prometheus.GaugeVec
+	DeviceOTAUpdateUpdating  *prometheus.GaugeVec
 	DeviceCurrentFirmware    *prometheus.GaugeVec
 	DeviceAvailableFirmware  *prometheus.GaugeVec
 }
@@ -173,16 +176,46 @@ func NewZ2MRegistry(baseRegistry *promexporter_metrics.Registry) *Z2MRegistry {
 
 	baseRegistry.AddMetricInfo("zigbee2mqtt_websocket_reconnects_total", "Total number of WebSocket reconnections", []string{})
 
-	// OTA Update metrics
-	z2m.DeviceOTAUpdateAvailable = factory.NewGaugeVec(
+	// OTA Update metrics - one per state, value is 1 when device is in that state
+	z2m.DeviceOTAUpdateIdle = factory.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "zigbee2mqtt_device_ota_update_available",
-			Help: "Device OTA update availability (1=available, 0=not_available)",
+			Name: "zigbee2mqtt_device_ota_update_idle",
+			Help: "Device OTA update state: idle (1=in this state)",
 		},
 		[]string{"device"},
 	)
 
-	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_available", "Device OTA update availability (1=available, 0=not_available)", []string{"device"})
+	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_idle", "Device OTA update state: idle (1=in this state)", []string{"device"})
+
+	z2m.DeviceOTAUpdateAvailable = factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "zigbee2mqtt_device_ota_update_available",
+			Help: "Device OTA update state: available (1=in this state)",
+		},
+		[]string{"device"},
+	)
+
+	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_available", "Device OTA update state: available (1=in this state)", []string{"device"})
+
+	z2m.DeviceOTAUpdateScheduled = factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "zigbee2mqtt_device_ota_update_scheduled",
+			Help: "Device OTA update state: scheduled (1=in this state)",
+		},
+		[]string{"device"},
+	)
+
+	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_scheduled", "Device OTA update state: scheduled (1=in this state)", []string{"device"})
+
+	z2m.DeviceOTAUpdateUpdating = factory.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "zigbee2mqtt_device_ota_update_updating",
+			Help: "Device OTA update state: updating (1=in this state)",
+		},
+		[]string{"device"},
+	)
+
+	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_updating", "Device OTA update state: updating (1=in this state)", []string{"device"})
 
 	z2m.DeviceCurrentFirmware = factory.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
## Summary

- Replaces the single `zigbee2mqtt_device_ota_update_available` gauge with four separate gauges, one per Z2M OTA state
- Each gauge is `1` when the device is in that state, `0` otherwise:
  - `zigbee2mqtt_device_ota_update_idle{device}`
  - `zigbee2mqtt_device_ota_update_available{device}`
  - `zigbee2mqtt_device_ota_update_scheduled{device}`
  - `zigbee2mqtt_device_ota_update_updating{device}`
- Alerts can now target `available` only, without firing during in-progress (`scheduled`/`updating`) updates
- Updated README with metric descriptions and example PromQL queries

## Test plan
- [ ] `go test ./internal/...` passes
- [ ] CI passes
- [ ] `zigbee2mqtt_device_ota_update_available == 1` only fires for devices needing action