### PR TITLE
refactor: replace four OTA gauge metrics with single zigbee2mqtt_device_ota{state} metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,7 @@ A Prometheus exporter for Zigbee2MQTT that connects to the WebSocket API and exp
 - `zigbee2mqtt_device_info{device,type,power_source,manufacturer,model_id,supported,disabled,interview_state,software_build_id,date_code}` - Device information (always 1, used for joining)
 
 ### OTA Update Metrics
-- `zigbee2mqtt_device_ota_update_idle{device}` - Device OTA state: idle (1=in this state)
-- `zigbee2mqtt_device_ota_update_available{device}` - Device OTA state: available (1=in this state)
-- `zigbee2mqtt_device_ota_update_scheduled{device}` - Device OTA state: scheduled (1=in this state)
-- `zigbee2mqtt_device_ota_update_updating{device}` - Device OTA state: updating (1=in this state)
+- `zigbee2mqtt_device_ota{device,state}` - Device OTA update state (state=idle|available|scheduled|updating, value is 1 when device is in that state)
 - `zigbee2mqtt_device_current_firmware_version{device,firmware_version}` - Device current firmware version (always 1, used for joining)
 - `zigbee2mqtt_device_available_firmware_version{device,firmware_version}` - Device available firmware version (always 1, used for joining)
 
@@ -143,19 +140,17 @@ count by (type) (zigbee2mqtt_device_info)
 
 ### Get devices with OTA updates available
 ```promql
-zigbee2mqtt_device_ota_update_available == 1
+zigbee2mqtt_device_ota{state="available"} == 1
 ```
 
 ### Get devices currently updating
 ```promql
-zigbee2mqtt_device_ota_update_updating == 1
+zigbee2mqtt_device_ota{state="updating"} == 1
 ```
 
 ### Get count of devices in each OTA state
 ```promql
-sum(zigbee2mqtt_device_ota_update_available)
-sum(zigbee2mqtt_device_ota_update_scheduled)
-sum(zigbee2mqtt_device_ota_update_updating)
+count by (state) (zigbee2mqtt_device_ota == 1)
 ```
 
 ### Get unsupported devices

--- a/internal/collectors/z2m_collector.go
+++ b/internal/collectors/z2m_collector.go
@@ -581,11 +581,7 @@ func (c *Z2MCollector) processBridgeDevicesMessage(ctx context.Context, msg Z2MM
 				idle, available = 0.0, 1.0
 			}
 
-			labels := prometheus.Labels{"device": device.FriendlyName}
-			c.metrics.DeviceOTAUpdateIdle.With(labels).Set(idle)
-			c.metrics.DeviceOTAUpdateAvailable.With(labels).Set(available)
-			c.metrics.DeviceOTAUpdateScheduled.With(labels).Set(0)
-			c.metrics.DeviceOTAUpdateUpdating.With(labels).Set(0)
+			c.setOTAState(device.FriendlyName, idle, available, 0, 0)
 		}
 
 		return
@@ -1074,6 +1070,13 @@ func (c *Z2MCollector) processDeviceMessage(ctx context.Context, msg Z2MMessage)
 }
 
 // updateDeviceMetrics updates Prometheus metrics for a device
+func (c *Z2MCollector) setOTAState(device string, idle, available, scheduled, updating float64) {
+	c.metrics.DeviceOTAState.With(prometheus.Labels{"device": device, "state": "idle"}).Set(idle)
+	c.metrics.DeviceOTAState.With(prometheus.Labels{"device": device, "state": "available"}).Set(available)
+	c.metrics.DeviceOTAState.With(prometheus.Labels{"device": device, "state": "scheduled"}).Set(scheduled)
+	c.metrics.DeviceOTAState.With(prometheus.Labels{"device": device, "state": "updating"}).Set(updating)
+}
+
 func (c *Z2MCollector) updateDeviceMetrics(ctx context.Context, deviceName string, data map[string]interface{}) {
 	tracer := c.app.GetTracer()
 
@@ -1234,12 +1237,7 @@ func (c *Z2MCollector) updateDeviceMetrics(ctx context.Context, deviceName strin
 				}
 			}
 
-			labels := prometheus.Labels{"device": deviceName}
-			c.metrics.DeviceOTAUpdateIdle.With(labels).Set(idle)
-			c.metrics.DeviceOTAUpdateAvailable.With(labels).Set(available)
-			c.metrics.DeviceOTAUpdateScheduled.With(labels).Set(scheduled)
-			c.metrics.DeviceOTAUpdateUpdating.With(labels).Set(updating)
-
+			c.setOTAState(deviceName, idle, available, scheduled, updating)
 			metricsUpdated += 4
 
 			if span != nil {

--- a/internal/collectors/z2m_collector.go
+++ b/internal/collectors/z2m_collector.go
@@ -1238,6 +1238,7 @@ func (c *Z2MCollector) updateDeviceMetrics(ctx context.Context, deviceName strin
 			}
 
 			c.setOTAState(deviceName, idle, available, scheduled, updating)
+
 			metricsUpdated += 4
 
 			if span != nil {

--- a/internal/collectors/z2m_collector_integration_test.go
+++ b/internal/collectors/z2m_collector_integration_test.go
@@ -137,8 +137,9 @@ func TestZ2MCollectorIntegration(t *testing.T) {
 	t.Logf("Device battery metric: %f", deviceBatteryMetric)
 
 	// Test OTA update metrics
-	deviceOTAUpdateMetric := testutil.ToFloat64(registry.DeviceOTAUpdateAvailable.With(prometheus.Labels{
+	deviceOTAUpdateMetric := testutil.ToFloat64(registry.DeviceOTAState.With(prometheus.Labels{
 		"device": "test-device",
+		"state":  "available",
 	}))
 	t.Logf("Device OTA update metric: %f", deviceOTAUpdateMetric)
 
@@ -270,10 +271,10 @@ func TestZ2MCollectorLabelConsistency(t *testing.T) {
 			description: "Should accept 'device' label",
 		},
 		{
-			name:        "DeviceOTAUpdateAvailable",
-			metric:      registry.DeviceOTAUpdateAvailable,
-			labels:      prometheus.Labels{"device": "test-device"},
-			description: "Should accept 'device' label",
+			name:        "DeviceOTAState",
+			metric:      registry.DeviceOTAState,
+			labels:      prometheus.Labels{"device": "test-device", "state": "available"},
+			description: "Should accept 'device' and 'state' labels",
 		},
 		{
 			name:        "DeviceCurrentFirmware",

--- a/internal/collectors/z2m_collector_test.go
+++ b/internal/collectors/z2m_collector_test.go
@@ -74,6 +74,7 @@ func TestUpdateDeviceMetrics_OTAState(t *testing.T) {
 
 			check := func(state string, want float64) {
 				t.Helper()
+
 				labels := prometheus.Labels{"device": "test_device", "state": state}
 				if got := testutil.ToFloat64(registry.DeviceOTAState.With(labels)); got != want {
 					t.Errorf("OTA state %q: zigbee2mqtt_device_ota{state=%q} = %v, want %v", tt.otaState, state, got, want)

--- a/internal/collectors/z2m_collector_test.go
+++ b/internal/collectors/z2m_collector_test.go
@@ -72,19 +72,18 @@ func TestUpdateDeviceMetrics_OTAState(t *testing.T) {
 
 			collector.updateDeviceMetrics(context.Background(), "test_device", payload)
 
-			labels := prometheus.Labels{"device": "test_device"}
-			check := func(name string, vec *prometheus.GaugeVec, want float64) {
+			check := func(state string, want float64) {
 				t.Helper()
-
-				if got := testutil.ToFloat64(vec.With(labels)); got != want {
-					t.Errorf("OTA state %q: %s = %v, want %v", tt.otaState, name, got, want)
+				labels := prometheus.Labels{"device": "test_device", "state": state}
+				if got := testutil.ToFloat64(registry.DeviceOTAState.With(labels)); got != want {
+					t.Errorf("OTA state %q: zigbee2mqtt_device_ota{state=%q} = %v, want %v", tt.otaState, state, got, want)
 				}
 			}
 
-			check("idle", registry.DeviceOTAUpdateIdle, tt.wantIdle)
-			check("available", registry.DeviceOTAUpdateAvailable, tt.wantAvail)
-			check("scheduled", registry.DeviceOTAUpdateScheduled, tt.wantSched)
-			check("updating", registry.DeviceOTAUpdateUpdating, tt.wantUpd)
+			check("idle", tt.wantIdle)
+			check("available", tt.wantAvail)
+			check("scheduled", tt.wantSched)
+			check("updating", tt.wantUpd)
 		})
 	}
 }

--- a/internal/metrics/z2m_registry.go
+++ b/internal/metrics/z2m_registry.go
@@ -33,9 +33,9 @@ type Z2MRegistry struct {
 	WebSocketReconnectsTotal  *prometheus.CounterVec
 
 	// OTA Update metric - state label is idle|available|scheduled|updating, value is 1 when device is in that state
-	DeviceOTAState *prometheus.GaugeVec
-	DeviceCurrentFirmware    *prometheus.GaugeVec
-	DeviceAvailableFirmware  *prometheus.GaugeVec
+	DeviceOTAState          *prometheus.GaugeVec
+	DeviceCurrentFirmware   *prometheus.GaugeVec
+	DeviceAvailableFirmware *prometheus.GaugeVec
 }
 
 // NewZ2MRegistry creates a new Z2M metrics registry

--- a/internal/metrics/z2m_registry.go
+++ b/internal/metrics/z2m_registry.go
@@ -32,11 +32,8 @@ type Z2MRegistry struct {
 	WebSocketMessagesTotal    *prometheus.CounterVec
 	WebSocketReconnectsTotal  *prometheus.CounterVec
 
-	// OTA Update metrics - one per state, value is 1 when device is in that state
-	DeviceOTAUpdateIdle      *prometheus.GaugeVec
-	DeviceOTAUpdateAvailable *prometheus.GaugeVec
-	DeviceOTAUpdateScheduled *prometheus.GaugeVec
-	DeviceOTAUpdateUpdating  *prometheus.GaugeVec
+	// OTA Update metric - state label is idle|available|scheduled|updating, value is 1 when device is in that state
+	DeviceOTAState *prometheus.GaugeVec
 	DeviceCurrentFirmware    *prometheus.GaugeVec
 	DeviceAvailableFirmware  *prometheus.GaugeVec
 }
@@ -176,46 +173,15 @@ func NewZ2MRegistry(baseRegistry *promexporter_metrics.Registry) *Z2MRegistry {
 
 	baseRegistry.AddMetricInfo("zigbee2mqtt_websocket_reconnects_total", "Total number of WebSocket reconnections", []string{})
 
-	// OTA Update metrics - one per state, value is 1 when device is in that state
-	z2m.DeviceOTAUpdateIdle = factory.NewGaugeVec(
+	z2m.DeviceOTAState = factory.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "zigbee2mqtt_device_ota_update_idle",
-			Help: "Device OTA update state: idle (1=in this state)",
+			Name: "zigbee2mqtt_device_ota",
+			Help: "Device OTA update state (state=idle|available|scheduled|updating, value is 1 when device is in that state)",
 		},
-		[]string{"device"},
+		[]string{"device", "state"},
 	)
 
-	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_idle", "Device OTA update state: idle (1=in this state)", []string{"device"})
-
-	z2m.DeviceOTAUpdateAvailable = factory.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "zigbee2mqtt_device_ota_update_available",
-			Help: "Device OTA update state: available (1=in this state)",
-		},
-		[]string{"device"},
-	)
-
-	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_available", "Device OTA update state: available (1=in this state)", []string{"device"})
-
-	z2m.DeviceOTAUpdateScheduled = factory.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "zigbee2mqtt_device_ota_update_scheduled",
-			Help: "Device OTA update state: scheduled (1=in this state)",
-		},
-		[]string{"device"},
-	)
-
-	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_scheduled", "Device OTA update state: scheduled (1=in this state)", []string{"device"})
-
-	z2m.DeviceOTAUpdateUpdating = factory.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "zigbee2mqtt_device_ota_update_updating",
-			Help: "Device OTA update state: updating (1=in this state)",
-		},
-		[]string{"device"},
-	)
-
-	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota_update_updating", "Device OTA update state: updating (1=in this state)", []string{"device"})
+	baseRegistry.AddMetricInfo("zigbee2mqtt_device_ota", "Device OTA update state (state=idle|available|scheduled|updating, value is 1 when device is in that state)", []string{"device", "state"})
 
 	z2m.DeviceCurrentFirmware = factory.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
## Summary
- Replaces `zigbee2mqtt_device_ota_update_idle`, `_available`, `_scheduled`, `_updating` (four separate metrics) with a single `zigbee2mqtt_device_ota{device, state}` metric.
- The `state` label is `idle|available|scheduled|updating`; value is 1 when the device is in that state, 0 otherwise.
- Query examples updated in README — use `zigbee2mqtt_device_ota{state="available"} == 1` and `count by (state) (zigbee2mqtt_device_ota == 1)`.

## Test plan
- [ ] All existing OTA tests pass with updated label assertions
- [ ] `go test ./internal/collectors/...` green