### PR TITLE
test: add regression test for device firmware metric labels

### DIFF
--- a/internal/collectors/z2m_collector_test.go
+++ b/internal/collectors/z2m_collector_test.go
@@ -51,6 +51,7 @@ func TestDeviceFirmware_LabelsMatchRegistry(t *testing.T) {
 			t.Fatalf("unexpected panic: %v", r)
 		}
 	}()
+
 	registry.DeviceCurrentFirmware.With(prometheus.Labels{
 		"device":           "test-device",
 		"firmware_version": "1.2.3",

--- a/internal/collectors/z2m_collector_test.go
+++ b/internal/collectors/z2m_collector_test.go
@@ -39,6 +39,28 @@ func TestNewZ2MCollector(t *testing.T) {
 	}
 }
 
+// TestDeviceFirmware_LabelsMatchRegistry guards against the label-name
+// mismatch between the registry definitions (device, firmware_version) and
+// the call sites in processBridgeDevicesMessage. If the labels drift again,
+// prometheus.Labels.With() panics here.
+func TestDeviceFirmware_LabelsMatchRegistry(t *testing.T) {
+	_, registry := newTestCollector(t)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}()
+	registry.DeviceCurrentFirmware.With(prometheus.Labels{
+		"device":           "test-device",
+		"firmware_version": "1.2.3",
+	}).Set(1)
+	registry.DeviceAvailableFirmware.With(prometheus.Labels{
+		"device":           "test-device",
+		"firmware_version": "1.2.4",
+	}).Set(1)
+}
+
 func TestUpdateDeviceMetrics_OTAState(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Summary
Follow-up to #642. Adds a regression test that constructs the registry and exercises both \`DeviceCurrentFirmware\` and \`DeviceAvailableFirmware\` with the call-site labels. If the labels ever drift again from the registered \`(device, firmware_version)\` dimension, \`prometheus.Labels.With()\` will panic in this test instead of in production.

## Test plan
- [x] \`go test ./internal/collectors/...\` passes