### PR TITLE
chore(make): stop masking test failures with || true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:
 
 # Run tests
 test:
-	go test -v -race -coverprofile=coverage.txt -covermode=atomic ./internal/... || true
+	go test -v -race -coverprofile=coverage.txt -covermode=atomic ./internal/...
 
 # Format code using golangci-lint formatters (faster than separate tools)
 fmt:


### PR DESCRIPTION
## Summary
`make test` was running `go test ... || true` so red tests silently exited 0. Drop the `|| true` so CI fails on actual test failures.

## Test plan
- [x] `go test ./...` passes locally