### PR TITLE
chore: standardize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 5m
-  go: "1.25.1"
+  go: "1.25.0"
 
 linters:
   # Use fast linters for better performance
@@ -43,6 +43,8 @@ linters:
     - usetesting  # Not critical
     - varnamelen  # Variable names fine
     - wsl  # Use wsl_v5 instead
+    - gocyclo  # Allow complex functions for SNMP data processing
+    - maintidx  # Allow complex registry functions
 
   settings:
     gosec:


### PR DESCRIPTION
Align `.golangci.yml` with the shared canonical config.

- Pin `run.go` to the repo's own `go.mod` version (`1.25.0`).
- Disable `gocyclo` and `maintidx` to match the canonical config.

CI already runs golangci-lint via the existing `lint` job (`make lint-only`), so no workflow changes are needed. `golangci-lint run` reports 0 issues locally with golangci-lint v2.12.2.